### PR TITLE
処理の重複防止(別ファイル保存実装)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,20 +1,18 @@
-# main.py
-
 import os
 import glob
-from scripts.distortion import IntegratedVideoProcessor
-# from scripts.downloader import download_file_from_google_drive
-import logging
+import time
 import json
+from scripts.distortion import IntegratedVideoProcessor
+import logging
 
 # ===== 設定セクション（ここで全てを調整可能） =====
 DISTORTION_CONFIG = {
     # 歪み補正パラメータ（yolo_checker.py準拠の高精度補正）
     "k1": -0.20,        # 120°広角レンズ用の強めの逆バレル補正
-    "k2": -0.001,         # 広角レンズの二次歪みを補正
+    "k2": -0.001,       # 広角レンズの二次歪みを補正
     "p1": 0.0,          # 接線歪み係数1
     "p2": 0.0,          # 接線歪み係数2
-    "k3": 0.012,         # 第3歪み係数
+    "k3": 0.012,        # 第3歪み係数
     "alpha": 0.8,       # 広角なので切り抜き重視
     "focal_scale": 0.85, # 広角効果を少し抑える
     "apply_correction": True,
@@ -34,6 +32,15 @@ MODEL_CONFIG = {
     "model_path": "models/yolo11x-pose.pt",
     "conf_threshold": 0.4,      # 検出信頼度閾値
     "phone_distance_threshold": 100, # スマホ使用判定距離
+}
+
+# スマートファイル管理設定
+SMART_FILE_MANAGEMENT_CONFIG = {
+    "enabled": True,                 # スマートファイル管理の有効/無効
+    "force_process": False,          # 強制処理フラグ
+    "quality_threshold": 1.0,        # 品質劣化防止閾値（1.0 = 同等時間以上で処理）
+    "backup_existing": False,        # 既存ファイルのバックアップ
+    "detailed_logging": True,        # 詳細ログ出力
 }
 # ===================================================
 
@@ -57,11 +64,36 @@ def find_video_files(video_dir="videos"):
     video_files.sort()
     return video_files
 
+def estimate_processing_time(video_path):
+    """動画の処理時間を推定"""
+    try:
+        import cv2
+        cap = cv2.VideoCapture(video_path)
+        if not cap.isOpened():
+            return 0
+
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        cap.release()
+
+        # 基本推定式（実際の環境に応じて調整してください）
+        base_time_per_frame = 0.1  # 1フレームあたりの基本処理時間
+        resolution_factor = (width * height) / (1920 * 1080)  # 解像度係数
+
+        estimated_time = total_frames * base_time_per_frame * resolution_factor
+        return estimated_time
+
+    except Exception as e:
+        logger.warning(f"処理時間推定エラー: {e}")
+        return 0
+
 def select_video_file():
     """動画ファイルを手動選択"""
     video_dir = "videos"
 
-    # videosディレクトリが存在しない場合は作成(gitから持ってくる場合に使う)
+    # videosディレクトリが存在しない場合は作成
     if not os.path.exists(video_dir):
         os.makedirs(video_dir)
         logger.info(f"videosディレクトリを作成: {video_dir}")
@@ -88,7 +120,11 @@ def select_video_file():
         else:
             size_str = f"{file_size} bytes"
 
-        logger.info(f"  {i}. {file_name} ({size_str})")
+        # 推定処理時間も表示
+        estimated_time = estimate_processing_time(video_file)
+        time_str = f"約{estimated_time:.1f}秒" if estimated_time > 0 else "不明"
+
+        logger.info(f"  {i}. {file_name} ({size_str}, 推定処理時間: {time_str})")
 
     # ユーザーのファイル選択
     while True:
@@ -114,9 +150,197 @@ def select_video_file():
         except Exception as e:
             logger.error(f"選択エラー: {e}")
 
+def process_with_smart_management(processor, video_path):
+    """スマートファイル管理による動画処理（品質劣化防止機能強化）"""
+    logger.info("=== スマートファイル管理による処理開始 ===")
+    logger.info("主な機能:")
+    logger.info("  ✓ 動画別ファイル管理（ハッシュベース）")
+    logger.info("  ✓ 推論時間による自動上書き制御")
+    logger.info("  ✓ 処理履歴の永続化")
+    logger.info("  ✓ 重複処理の自動検出・防止")
+    logger.info("  ✓ 品質劣化防止機能（推定時間短縮時の保護）")
+    logger.info(f"  ✓ 品質閾値: {SMART_FILE_MANAGEMENT_CONFIG['quality_threshold']:.1f}倍")
+
+    # スマートファイル管理のインスタンスに品質閾値を設定
+    processor.file_manager.quality_threshold = SMART_FILE_MANAGEMENT_CONFIG["quality_threshold"]
+
+    # スマートファイル管理による動画処理実行
+    success = processor.process_video_with_smart_management(
+        input_path=video_path,
+        show_preview=VIDEO_CONFIG["show_preview"],
+        apply_correction=DISTORTION_CONFIG["apply_correction"],
+        force_process=SMART_FILE_MANAGEMENT_CONFIG["force_process"]
+    )
+
+    # 生成されたファイルパスを取得（スマートファイル管理から）
+    file_paths = {}
+    if hasattr(processor, 'file_manager'):
+        try:
+            estimated_time = processor.estimate_processing_time(video_path)
+            _, _, file_paths = processor.file_manager.should_process_video(
+                video_path, estimated_time, False
+            )
+        except Exception as e:
+            logger.warning(f"ファイルパス取得エラー: {e}")
+
+    return success, file_paths
+
+def process_with_smart_management(processor, video_path):
+    """スマートファイル管理による動画処理（品質劣化防止機能強化）"""
+    logger.info("=== スマートファイル管理による処理開始 ===")
+    logger.info("主な機能:")
+    logger.info("  ✓ 動画別ファイル管理（ハッシュベース）")
+    logger.info("  ✓ 推論時間による自動上書き制御")
+    logger.info("  ✓ 処理履歴の永続化")
+    logger.info("  ✓ 重複処理の自動検出・防止")
+    logger.info("  ✓ 品質劣化防止機能（推定時間短縮時の保護）")
+    logger.info(f"  ✓ 品質閾値: {SMART_FILE_MANAGEMENT_CONFIG['quality_threshold']:.1f}倍")
+    logger.info(f"  ✓ CSV保護: 動画・基本CSV・拡張CSV全て同時保護")
+
+    # スマートファイル管理のインスタンスに品質閾値を設定
+    processor.file_manager.quality_threshold = SMART_FILE_MANAGEMENT_CONFIG["quality_threshold"]
+
+    # スマートファイル管理による動画処理実行
+    success = processor.process_video_with_smart_management(
+        input_path=video_path,
+        show_preview=VIDEO_CONFIG["show_preview"],
+        apply_correction=DISTORTION_CONFIG["apply_correction"],
+        force_process=SMART_FILE_MANAGEMENT_CONFIG["force_process"]
+    )
+
+    # 生成されたファイルパスを取得（スマートファイル管理から）
+    file_paths = {}
+    if hasattr(processor, 'file_manager'):
+        try:
+            estimated_time = processor.estimate_processing_time(video_path)
+            _, _, file_paths = processor.file_manager.should_process_video(
+                video_path, estimated_time, False
+            )
+        except Exception as e:
+            logger.warning(f"ファイルパス取得エラー: {e}")
+
+    return success, file_paths
+
+# process_with_traditional_method 関数を追加
+def process_with_traditional_method(processor, video_path):
+    """従来方式での動画処理"""
+    logger.info("=== 従来方式による処理開始 ===")
+
+    # 出力ファイル名生成（従来方式）
+    video_basename = os.path.splitext(os.path.basename(video_path))[0]
+    output_dir = "videos"
+    data_dir = "data"
+
+    output_video = os.path.join(output_dir, f"output_{video_basename}_advanced_posture_detection.mp4")
+    result_log = os.path.join(data_dir, f"frame_results_{video_basename}.csv")
+    enhanced_csv_path = os.path.join(data_dir, f"enhanced_detection_log_{video_basename}.csv")
+
+    # 既存ファイルの削除（従来方式）
+    for file_path in [output_video, result_log, enhanced_csv_path]:
+        if os.path.exists(file_path):
+            os.remove(file_path)
+            logger.info(f"既存ファイルを削除: {os.path.basename(file_path)}")
+
+    # 拡張CSVロガーを設定
+    if VIDEO_CONFIG["enable_enhanced_csv"]:
+        processor.set_csv_logger(enhanced_csv_path, overwrite_existing=True)
+
+    # 動画処理実行
+    success = processor.process_video(
+        input_path=video_path,
+        output_path=output_video,
+        result_log=result_log,
+        show_preview=VIDEO_CONFIG["show_preview"],
+        apply_correction=DISTORTION_CONFIG["apply_correction"]
+    )
+
+    return success, {
+        "output_video": output_video,
+        "result_log": result_log,
+        "enhanced_csv": enhanced_csv_path
+    }
+
+def display_processing_results(success, file_paths, total_processing_time, processor):
+    """処理結果の表示"""
+    if success:
+        logger.info("=== 処理完了 ===")
+        logger.info(f"総処理時間: {total_processing_time:.1f}秒")
+
+        # ファイル情報の表示
+        logger.info("=== 生成ファイル情報 ===")
+        for key, path in file_paths.items():
+            if key not in ["video_hash", "video_basename"] and os.path.exists(path):
+                file_size = os.path.getsize(path)
+                size_mb = file_size / (1024 * 1024)
+                logger.info(f"{key}: {os.path.basename(path)} ({size_mb:.1f}MB)")
+
+        # 統計情報を取得
+        try:
+            stats = processor.get_statistics()
+            logger.info("=== 最終統計情報 ===")
+            logger.info(f"アクティブトラック数: {stats['active_tracks']}")
+            logger.info(f"総CSV記録数: {stats['total_csv_records']}")
+            logger.info(f"追跡ID一覧: {stats['track_ids']}")
+        except Exception as e:
+            logger.warning(f"統計情報取得エラー: {e}")
+
+        # 処理履歴の確認（スマートファイル管理の場合）
+        if SMART_FILE_MANAGEMENT_CONFIG["enabled"]:
+            try:
+                history_file = "data/video_processing_history.json"
+                if os.path.exists(history_file):
+                    with open(history_file, 'r', encoding='utf-8') as f:
+                        history = json.load(f)
+
+                    logger.info("=== 処理履歴サマリー ===")
+                    logger.info(f"記録済み動画数: {len(history)}動画")
+
+                    for video_hash, record in history.items():
+                        logger.info(f"  {record['video_basename']}: {record['execution_count']}回実行, "
+                                f"平均{record['fps_average']:.1f}fps")
+
+            except Exception as e:
+                logger.warning(f"処理履歴確認エラー: {e}")
+
+        logger.info("✅ 処理が正常に完了しました")
+
+        if SMART_FILE_MANAGEMENT_CONFIG["enabled"]:
+            logger.info("主な改善点の確認:")
+            logger.info("  ✓ 動画別の完全分離ファイル管理")
+            logger.info("  ✓ 推論時間による品質保護")
+            logger.info("  ✓ 自動重複防止システム")
+            logger.info("  ✓ 処理履歴の永続化")
+
+    else:
+        logger.warning("⚠️ 処理が完了しませんでした（スキップまたはエラー）")
+
+def save_processing_config(video_path, total_processing_time, smart_management_used):
+    """処理設定の保存"""
+    data_dir = "data"
+    config_file = os.path.join(data_dir, "processing_config.json")
+
+    config_data = {
+        "distortion_config": DISTORTION_CONFIG,
+        "video_config": VIDEO_CONFIG,
+        "model_config": MODEL_CONFIG,
+        "smart_file_management_config": SMART_FILE_MANAGEMENT_CONFIG,
+        "processing_timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "input_video": video_path,
+        "total_processing_time": total_processing_time,
+        "smart_file_management_used": smart_management_used
+    }
+
+    try:
+        with open(config_file, 'w', encoding='utf-8') as f:
+            json.dump(config_data, f, indent=2, ensure_ascii=False)
+        logger.info(f"設定ファイル保存: {config_file}")
+    except Exception as e:
+        logger.warning(f"設定ファイル保存エラー: {e}")
+
+
 def main():
-    """メイン関数（改良版）"""
-    logger.info("=== 改良版姿勢検出システム開始 ===")
+    """メイン関数（スマートファイル管理対応版）"""
+    logger.info("=== 改良版姿勢検出システム（スマートファイル管理版）開始 ===")
 
     # 設定情報の表示
     logger.info("設定情報:")
@@ -125,6 +349,7 @@ def main():
     logger.info(f"  alpha={DISTORTION_CONFIG['alpha']}, focal_scale={DISTORTION_CONFIG['focal_scale']}")
     logger.info(f"  プレビュー: {'有効' if VIDEO_CONFIG['show_preview'] else '無効'}")
     logger.info(f"  拡張CSV: {'有効' if VIDEO_CONFIG['enable_enhanced_csv'] else '無効'}")
+    logger.info(f"  スマートファイル管理: {'有効' if SMART_FILE_MANAGEMENT_CONFIG['enabled'] else '無効'}")
 
     # 動画ファイル選択
     logger.info("=== 動画ファイル選択 ===")
@@ -144,8 +369,8 @@ def main():
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(data_dir, exist_ok=True)
 
-    # 統合処理システムを初期化（改良版）
-    logger.info("改良版統合処理システムを初期化中...")
+    # 統合処理システムを初期化（スマートファイル管理対応）
+    logger.info("スマートファイル管理対応統合処理システムを初期化中...")
     processor = IntegratedVideoProcessor(
         k1=DISTORTION_CONFIG["k1"],
         k2=DISTORTION_CONFIG["k2"],
@@ -157,159 +382,32 @@ def main():
         model_path=MODEL_CONFIG["model_path"]
     )
 
-    # 動画ファイル名を基にCSVファイル名を生成
-    video_basename = os.path.splitext(os.path.basename(video_path))[0]
-    enhanced_csv_path = None
-
-    # 拡張CSVロガーを有効化
-    if VIDEO_CONFIG["enable_enhanced_csv"]:
-        enhanced_csv_path = os.path.join(data_dir, f"enhanced_detection_log_{video_basename}.csv")
-
-        # 既存ファイル削除（クリーンスタート）
-        if os.path.exists(enhanced_csv_path):
-            os.remove(enhanced_csv_path)
-            logger.info(f"既存の拡張CSVファイルを削除: {enhanced_csv_path}")
-
-        # 拡張CSVロガーを設定
-        processor.set_csv_logger(enhanced_csv_path)
-
-        if processor.csv_logger is not None:
-            logger.info(f"拡張CSVロガー有効化成功: {enhanced_csv_path}")
-            logger.info(f"ヘッダー列数: {len(processor.csv_logger.headers)}")
-        else:
-            logger.error("拡張CSVロガー有効化失敗")
-            return
-
-    # 出力パスの設定(動画ファイルをもとに生成)
-    output_video = os.path.join(output_dir, f"output_{video_basename}_advanced_posture_detection.mp4")
-    result_log = os.path.join(data_dir, f"frame_results_{video_basename}.csv")
-
-    # 既存ファイル削除（クリーンスタート）
-    for file_path in [output_video, result_log]:
-        if os.path.exists(file_path):
-            os.remove(file_path)
-            logger.info(f"既存ファイルを削除: {file_path}")
-
-    logger.info("=== 改良版処理開始 ===")
-    logger.info(f"入力動画: {video_path}")
-    logger.info(f"出力動画: {output_video}")
-    logger.info(f"基本結果ログ: {result_log}")
-    if enhanced_csv_path:
-        logger.info(f"拡張結果ログ: {enhanced_csv_path}")
-    logger.info("改良内容:")
-    logger.info("  - 詳細な状態分類（PhoneUsageState）")
-    logger.info("  - 前向き・後ろ向きの自動判定")
-    logger.info("  - 高度な特徴量抽出システム")
-    logger.info("  - 5係数を使用した高精度歪み補正")
-    logger.info("  - 向き別の最適化されたスマホ検出")
+    logger.info("=== スマートファイル管理による処理開始 ===")
+    logger.info("主な機能:")
+    logger.info("  ✓ 動画別ファイル管理（ハッシュベース）")
+    logger.info("  ✓ 推論時間による自動上書き制御")
+    logger.info("  ✓ 処理履歴の永続化")
+    logger.info("  ✓ 重複処理の自動検出・防止")
+    logger.info("  ✓ 品質劣化防止機能")
 
     try:
-        # 動画処理実行
-        processor.process_video(
-            input_path=video_path,
-            output_path=output_video,
-            result_log=result_log,
-            show_preview=VIDEO_CONFIG["show_preview"],
-            apply_correction=DISTORTION_CONFIG["apply_correction"]
-        )
+        # 処理開始時間記録
+        processing_start_time = time.time()
 
-        logger.info("=== 改良版処理完了 ===")
-
-        # 結果ファイルの確認と統計
-        files_to_check = [
-            (output_video, "出力動画"),
-            (result_log, "基本CSV"),
-        ]
-
-        if enhanced_csv_path:
-            files_to_check.append((enhanced_csv_path, "拡張CSV"))
-
-        for file_path, description in files_to_check:
-            if os.path.exists(file_path):
-                file_size = os.path.getsize(file_path)
-                # ファイルサイズを見やすい単位で表示
-                if file_size > 1024 * 1024:
-                    size_str = f"{file_size / (1024 * 1024):.1f} MB"
-                elif file_size > 1024:
-                    size_str = f"{file_size / 1024:.1f} KB"
-                else:
-                    size_str = f"{file_size} bytes"
-
-                logger.info(f"{description}: {file_path} ({size_str})")
-
-                # CSVファイルの行数チェック
-                if file_path.endswith('.csv'):
-                    try:
-                        with open(file_path, 'r') as f:
-                            line_count = sum(1 for _ in f) - 1  # ヘッダーを除く
-                        logger.info(f"データ行数: {line_count}")
-
-                        if line_count == 0:
-                            logger.warning(f"{description}にデータが記録されていません")
-                        else:
-                            logger.info(f"{description}に{line_count}行のデータが記録されました")
-
-                    except Exception as e:
-                        logger.error(f"{description}の行数確認エラー: {e}")
-            else:
-                logger.error(f"{description}ファイルが生成されていません: {file_path}")
-
-        # 統計情報取得
-        try:
-            stats = processor.get_statistics()
-            logger.info("=== 最終統計情報 ===")
-            logger.info(f"アクティブトラック数: {stats['active_tracks']}")
-            logger.info(f"総CSV記録数: {stats['total_csv_records']}")
-            logger.info(f"追跡ID一覧: {stats['track_ids']}")
-        except Exception as e:
-            logger.warning(f"統計情報取得エラー: {e}")
-
-        # 改良版の成果判定
-        success_criteria = [
-            (os.path.exists(output_video), "動画出力"),
-            (os.path.exists(result_log), "基本CSV出力"),
-        ]
-
-        if enhanced_csv_path:
-            success_criteria.append((
-                os.path.exists(enhanced_csv_path) and os.path.getsize(enhanced_csv_path) > 1000,
-                "拡張CSV出力"
-            ))
-
-        all_success = all(criteria for criteria, _ in success_criteria)
-
-        if all_success:
-            logger.info("✅ 改良版処理が正常に完了しました")
-            logger.info("主な改善点の確認:")
-            logger.info("  ✓ 詳細な姿勢状態分類システム")
-            logger.info("  ✓ 向き判定による最適化")
-            logger.info("  ✓ 高精度歪み補正")
-            logger.info("  ✓ 拡張データロギング")
+        # 処理方式の選択と実行
+        if SMART_FILE_MANAGEMENT_CONFIG["enabled"]:
+            success, file_paths = process_with_smart_management(processor, video_path)
         else:
-            logger.warning("⚠️ 一部の処理で問題が発生しました")
-            for success, name in success_criteria:
-                status = "✓" if success else "✗"
-                logger.info(f"    {status} {name}")
+            success, file_paths = process_with_traditional_method(processor, video_path)
+
+        # 処理時間計算
+        total_processing_time = time.time() - processing_start_time
+
+        # 処理結果の表示
+        display_processing_results(success, file_paths, total_processing_time, processor)
 
         # 設定情報の保存（デバッグ・再現用）
-        config_file = os.path.join(data_dir, "processing_config.json")
-        config_data = {
-            "distortion_config": DISTORTION_CONFIG,
-            "video_config": VIDEO_CONFIG,
-            "model_config": MODEL_CONFIG,
-            "processing_timestamp": str(logger.handlers[0].formatter.formatTime(logger.handlers[0], logging.LogRecord("", 0, "", 0, "", (), None))),
-            "input_video": video_path,
-            "output_video": output_video,
-            "result_log": result_log,
-            "enhanced_csv": enhanced_csv_path
-        }
-
-        try:
-            with open(config_file, 'w', encoding='utf-8') as f:
-                json.dump(config_data, f, indent=2, ensure_ascii=False)
-            logger.info(f"設定ファイル保存: {config_file}")
-        except Exception as e:
-            logger.warning(f"設定ファイル保存エラー: {e}")
+        save_processing_config(video_path, total_processing_time, SMART_FILE_MANAGEMENT_CONFIG["enabled"])
 
     except KeyboardInterrupt:
         logger.info("⏹️ ユーザーによって処理が中断されました")
@@ -320,7 +418,7 @@ def main():
     finally:
         # クリーンアップ
         try:
-            if processor.csv_logger:
+            if hasattr(processor, 'csv_logger') and processor.csv_logger:
                 processor.csv_logger.close()
         except:
             pass
@@ -364,6 +462,19 @@ def validate_environment():
         logger.warning(f"YOLOモデルが見つかりません: {model_path}")
         logger.info("モデルは初回実行時に自動ダウンロードされます")
 
+    # 処理履歴ファイルの確認（スマートファイル管理有効時のみ）
+    if SMART_FILE_MANAGEMENT_CONFIG["enabled"]:
+        history_file = "data/video_processing_history.json"
+        if os.path.exists(history_file):
+            try:
+                with open(history_file, 'r', encoding='utf-8') as f:
+                    history = json.load(f)
+                logger.info(f"処理履歴ファイル確認: {len(history)}件の記録")
+            except Exception as e:
+                logger.warning(f"処理履歴ファイル読み込みエラー: {e}")
+        else:
+            logger.info("処理履歴ファイルは初回実行時に作成されます")
+
 def show_system_info():
     """システム情報の表示"""
     logger.info("=== システム情報 ===")
@@ -387,38 +498,83 @@ def show_system_info():
     except:
         logger.warning("Ultralytics YOLOが利用できません")
 
+    try:
+        import hashlib
+        import json
+        logger.info("スマートファイル管理: 利用可能")
+    except:
+        logger.warning("スマートファイル管理が利用できません")
+
 def print_usage_help():
     """使用方法のヘルプ"""
-    print("""
-=== 改良版姿勢検出システム 使用方法 ===
+    print(f"""
+=== 改良版姿勢検出システム（統合版） 使用方法 ===
 
 【基本実行】
 python main.py
 
+【処理方式の選択】
+スマートファイル管理: {'有効' if SMART_FILE_MANAGEMENT_CONFIG['enabled'] else '無効'}
+
+【スマートファイル管理の特徴】（有効時）
+✓ 動画別ファイル管理：異なる動画は必ず別ファイルに保存
+✓ 推論時間制御：処理時間が向上する場合のみ上書き
+✓ 重複防止：同じ動画・同じ設定での無駄な再処理を防止
+✓ 履歴管理：処理履歴をJSONファイルで永続化
+
+【従来方式の特徴】（無効時）
+✓ シンプルな処理フロー
+✓ 毎回クリーンスタート
+✓ 固定ファイル名での出力
+
+【ファイル構成例】
+スマートファイル管理有効時:
+videos/
+├── output_sample_video_a1b2c3d4_advanced_posture_detection.mp4
+├── output_test_data_x1y2z3w4_advanced_posture_detection.mp4
+
+data/
+├── enhanced_detection_log_sample_video_a1b2c3d4.csv
+├── enhanced_detection_log_test_data_x1y2z3w4.csv
+├── frame_results_sample_video_a1b2c3d4.csv
+├── frame_results_test_data_x1y2z3w4.csv
+└── video_processing_history.json
+
+従来方式:
+videos/
+├── output_sample_video_advanced_posture_detection.mp4
+├── output_test_data_advanced_posture_detection.mp4
+
+data/
+├── enhanced_detection_log_sample_video.csv
+├── enhanced_detection_log_test_data.csv
+├── frame_results_sample_video.csv
+└── frame_results_test_data.csv
+
 【設定のカスタマイズ】
 main.py の設定セクションを編集してください：
 
-DISTORTION_CONFIG = {
-    "k1": -0.30,      # 歪み補正の強さ（負の値で逆バレル補正）
-    "alpha": 0.4,     # 切り抜き vs 画質のバランス
-    "apply_correction": True,  # 歪み補正の有効/無効
-}
+# スマートファイル管理の有効/無効
+SMART_FILE_MANAGEMENT_CONFIG = {{
+    "enabled": True,  # True: スマート管理, False: 従来方式
+    "force_process": False,  # 強制処理
+}}
 
-VIDEO_CONFIG = {
+DISTORTION_CONFIG = {{
+    "k1": -0.20,      # 歪み補正の強さ
+    "alpha": 0.8,     # 切り抜き vs 画質のバランス
+    "apply_correction": True,  # 歪み補正の有効/無効
+}}
+
+VIDEO_CONFIG = {{
     "show_preview": True,      # プレビュー表示
     "enable_enhanced_csv": True,  # 詳細CSV出力
-}
-
-【主な改良点】
-✓ 詳細な状態分類（6つの状態）
-✓ 前向き・後ろ向き自動判定
-✓ 高精度5係数歪み補正
-✓ 機械学習用拡張CSV出力
-✓ 統計情報とデバッグ支援
+}}
 
 【操作方法】
 - プレビュー表示中は 'q' キーで終了
-- 全ての結果は videos/ と data/ ディレクトリに保存されます
+- 再処理確認で 'y' を入力すると強制実行
+- 全ての結果は設定に応じて自動保存されます
 """)
 
 if __name__ == "__main__":

--- a/scripts/distortion.py
+++ b/scripts/distortion.py
@@ -3,6 +3,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 import os
 import time
+import hashlib
+import json
 from ultralytics import YOLO
 from collections import defaultdict, deque
 import logging
@@ -17,6 +19,231 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
+
+class VideoProcessingHistory:
+    """動画処理履歴管理クラス"""
+
+    def __init__(self, history_file="data/video_processing_history.json"):
+        self.history_file = history_file
+        self.history = self.load_history()
+
+    def load_history(self):
+        """処理履歴を読み込む"""
+        try:
+            if os.path.exists(self.history_file):
+                with open(self.history_file, 'r', encoding='utf-8') as f:
+                    return json.load(f)
+            return {}
+        except Exception as e:
+            logger.warning(f"処理履歴読み込みエラー: {e}")
+            return {}
+
+    def save_history(self):
+        """処理履歴を保存"""
+        try:
+            os.makedirs(os.path.dirname(self.history_file), exist_ok=True)
+            with open(self.history_file, 'w', encoding='utf-8') as f:
+                json.dump(self.history, f, indent=2, ensure_ascii=False)
+        except Exception as e:
+            logger.error(f"処理履歴保存エラー: {e}")
+
+    def get_video_hash(self, video_path):
+        """動画ファイルのハッシュ値を計算"""
+        try:
+            stat = os.stat(video_path)
+            hash_data = {
+                "basename": os.path.splitext(os.path.basename(video_path))[0],
+                "size": stat.st_size,
+                "mtime": stat.st_mtime
+            }
+            hash_str = json.dumps(hash_data, sort_keys=True)
+            return hashlib.md5(hash_str.encode()).hexdigest()[:16]
+        except Exception as e:
+            logger.error(f"動画ハッシュ計算エラー: {e}")
+            return None
+
+    def get_processing_record(self, video_hash):
+        """動画の処理記録を取得"""
+        return self.history.get(video_hash, None)
+
+    def should_overwrite(self, video_hash, estimated_processing_time, quality_threshold=1.0):
+        """上書きすべきかを判定（品質劣化防止機能強化）"""
+        record = self.get_processing_record(video_hash)
+
+        if record is None:
+            return True, "初回処理"
+
+        previous_time = record.get("processing_time", 0)
+
+        # 推定時間が0以下の場合は安全のため処理実行
+        if estimated_processing_time <= 0:
+            return True, "推定時間が無効のため安全処理"
+
+        # 前回の処理時間が0以下の場合は処理実行
+        if previous_time <= 0:
+            return True, "前回処理時間が無効のため再処理"
+
+        # 推定時間と前回処理時間の比較
+        time_ratio = estimated_processing_time / previous_time
+
+        # 推定時間が前回より長い場合（処理品質向上の可能性）
+        if time_ratio >= quality_threshold:
+            improvement_ratio = time_ratio
+            return True, f"処理品質向上期待 (推定時間が{improvement_ratio:.1f}倍に増加)"
+
+        # 推定時間が前回より短い場合（処理品質劣化の可能性）
+        else:
+            degradation_ratio = previous_time / estimated_processing_time
+            return False, f"処理品質劣化防止 (推定時間が{degradation_ratio:.1f}倍高速化→品質低下の可能性)"
+
+
+    def add_processing_record(self, video_hash, video_basename, processing_time, total_frames, output_files):
+        """処理記録を追加"""
+        record = {
+            "video_basename": video_basename,
+            "processing_time": processing_time,
+            "total_frames": total_frames,
+            "fps_average": total_frames / processing_time if processing_time > 0 else 0,
+            "timestamp": time.time(),
+            "execution_count": self.history.get(video_hash, {}).get("execution_count", 0) + 1,
+            "output_files": output_files
+        }
+        self.history[video_hash] = record
+        self.save_history()
+        return record
+
+class SmartFileManager:
+    """スマートファイル管理クラス"""
+
+    def __init__(self, base_output_dir="videos", base_data_dir="data", quality_threshold=1.0):
+        self.base_output_dir = base_output_dir
+        self.base_data_dir = base_data_dir
+        self.video_history = VideoProcessingHistory()
+        self.quality_threshold = quality_threshold  # 品質劣化防止閾値
+
+    def generate_output_paths(self, video_path):
+        """動画に基づいて出力パスを生成"""
+        video_basename = os.path.splitext(os.path.basename(video_path))[0]
+        video_hash = self.video_history.get_video_hash(video_path)
+
+        if video_hash is None:
+            # ハッシュ計算に失敗した場合は基本ファイル名のみ使用
+            suffix = ""
+            logger.warning("動画ハッシュ計算失敗、基本ファイル名のみ使用")
+        else:
+            suffix = f"_{video_hash}"
+
+        # 出力ファイルパス生成（動画別に分離）
+        output_video = os.path.join(
+            self.base_output_dir,
+            f"output_{video_basename}{suffix}_advanced_posture_detection.mp4"
+        )
+        basic_csv = os.path.join(
+            self.base_data_dir,
+            f"frame_results_{video_basename}{suffix}.csv"
+        )
+        enhanced_csv = os.path.join(
+            self.base_data_dir,
+            f"enhanced_detection_log_{video_basename}{suffix}.csv"
+        )
+
+        return {
+            "output_video": output_video,
+            "basic_csv": basic_csv,
+            "enhanced_csv": enhanced_csv,
+            "video_hash": video_hash,
+            "video_basename": video_basename
+        }
+
+    def check_existing_files(self, file_paths):
+        """既存ファイルの存在をチェック"""
+        existing_files = {}
+        for key, path in file_paths.items():
+            if key not in ["video_hash", "video_basename"] and os.path.exists(path):
+                existing_files[key] = {
+                    "path": path,
+                    "size": os.path.getsize(path),
+                    "mtime": os.path.getmtime(path)
+                }
+        return existing_files
+
+    def should_process_video(self, video_path, estimated_processing_time, force_process=False):
+        """動画を処理すべきかを判定"""
+        if force_process:
+            return True, "強制処理モード", {}
+
+        file_paths = self.generate_output_paths(video_path)
+        existing_files = self.check_existing_files(file_paths)
+
+        if not existing_files:
+            return True, "初回処理（ファイルなし）", file_paths
+
+        video_hash = file_paths["video_hash"]
+        if video_hash is None:
+            return True, "ハッシュ計算失敗（安全のため処理実行）", file_paths
+
+        # 品質劣化防止閾値を使用して判定
+        should_overwrite, reason = self.video_history.should_overwrite(
+            video_hash, estimated_processing_time, self.quality_threshold
+        )
+
+        if should_overwrite:
+            return True, reason, file_paths
+        else:
+            return False, reason, file_paths
+
+    def cleanup_existing_files(self, file_paths):
+        """既存ファイルを削除（品質向上時のみ - CSV保護機能付き）"""
+        logger.info("🔄 品質向上のため既存ファイルを削除中...")
+
+        deleted_files = []
+        for key, path in file_paths.items():
+            if key not in ["video_hash", "video_basename"] and os.path.exists(path):
+                try:
+                    # ファイル情報を記録
+                    file_size = os.path.getsize(path)
+                    size_mb = file_size / (1024 * 1024)
+
+                    os.remove(path)
+                    deleted_files.append((key, os.path.basename(path), size_mb))
+                    logger.info(f"品質向上のため削除: {os.path.basename(path)} ({size_mb:.1f}MB)")
+                except Exception as e:
+                    logger.error(f"ファイル削除エラー {path}: {e}")
+
+        if deleted_files:
+            logger.info(f"📁 削除完了: {len(deleted_files)}ファイル")
+            for key, filename, size_mb in deleted_files:
+                logger.info(f"  {key}: {filename} ({size_mb:.1f}MB)")
+        else:
+            logger.info("削除対象ファイルなし")
+
+    def log_processing_completion(self, video_path, file_paths, processing_time, total_frames):
+        """処理完了をログに記録"""
+        video_hash = file_paths["video_hash"]
+        video_basename = file_paths["video_basename"]
+
+        if video_hash is None:
+            logger.warning("動画ハッシュなしのため履歴記録をスキップ")
+            return
+
+        output_files = {
+            key: path for key, path in file_paths.items()
+            if key not in ["video_hash", "video_basename"]
+        }
+
+        record = self.video_history.add_processing_record(
+            video_hash, video_basename, processing_time, total_frames, output_files
+        )
+
+        # 処理品質情報をログ出力
+        fps_average = record.get("fps_average", 0)
+        execution_count = record.get("execution_count", 1)
+
+        logger.info(f"📊 処理品質記録更新:")
+        logger.info(f"  実行回数: {execution_count}回目")
+        logger.info(f"  処理時間: {processing_time:.1f}秒")
+        logger.info(f"  平均FPS: {fps_average:.1f}")
+        logger.info(f"  総フレーム数: {total_frames}")
 
 class PhoneUsageState(Enum):
     """スマホ使用状態の詳細分類"""
@@ -66,7 +293,7 @@ class DetectionResult:
 class EnhancedCSVLogger:
     """機械学習用拡張CSVロガー"""
 
-    def __init__(self, csv_path="enhanced_detection_log.csv", model_name="yolo11x-pose"):
+    def __init__(self, csv_path="enhanced_detection_log.csv", model_name="yolo11x-pose", overwrite_existing=True):
         self.csv_path = csv_path
         self.csv_file = None
         self.csv_writer = None
@@ -74,6 +301,8 @@ class EnhancedCSVLogger:
         self.log_count = 0
         # モデルを変更した時はここを更新
         self.model_name = model_name
+        # self.file_manager = SmartFileManager()  # スマートファイル管理を追加
+        self.overwrite_existing = overwrite_existing  # ← この行を追加
 
         # CSV ヘッダー定義
         self.headers = [
@@ -102,17 +331,33 @@ class EnhancedCSVLogger:
         """CSV ファイルを初期化"""
         try:
             # ディレクトリ作成
-            os.makedirs(os.path.dirname(self.csv_path), exist_ok=True)
+            csv_dir = os.path.dirname(self.csv_path)
+            if csv_dir:
+                os.makedirs(csv_dir, exist_ok=True)
 
+            # 既存ファイルのチェック
+            if os.path.exists(self.csv_path) and not self.overwrite_existing:
+                file_size = os.path.getsize(self.csv_path)
+                mod_time = os.path.getmtime(self.csv_path)
+                mod_time_str = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(mod_time))
+
+                logger.warning(f"拡張CSVファイルが既に存在: {os.path.basename(self.csv_path)}")
+                logger.warning(f"サイズ: {file_size:,} bytes, 更新: {mod_time_str}")
+                logger.warning("既存ファイルを保持します（重複防止）")
+
+                # ダミーファイルハンドルを作成（書き込みは無効化）
+                self.csv_file = None
+                self.csv_writer = None
+                return
+
+            # 新規作成または上書き
             self.csv_file = open(self.csv_path, 'w', newline='', encoding='utf-8')
             self.csv_writer = csv.writer(self.csv_file)
             self.csv_writer.writerow(self.headers)
-
-            # 即座にフラッシュしてヘッダーを書き込み
             self.csv_file.flush()
 
-            logger.info(f"拡張CSVログを初期化: {self.csv_path}")
-            logger.info(f"CSVヘッダー: {self.headers}")
+            logger.info(f"拡張CSVログ初期化: {os.path.basename(self.csv_path)}")
+            logger.info(f"CSVヘッダー列数: {len(self.headers)}")
 
         except Exception as e:
             logger.error(f"CSV初期化エラー: {e}")
@@ -120,6 +365,10 @@ class EnhancedCSVLogger:
 
     def log_detection_result_simplified(self, detection_result: DetectionResult, keypoints, yolo_confidence=0.0):
         """DetectionResultオブジェクトから拡張CSVにログを記録"""
+        # CSVライターが無効化されている場合はスキップ
+        if self.csv_writer is None:
+            return
+
         try:
             self.log_count += 1
             current_time = time.time()
@@ -183,10 +432,12 @@ class EnhancedCSVLogger:
             if self.csv_file:
                 self.csv_file.flush()
                 self.csv_file.close()
-                logger.info(f"CSVログ保存完了: {self.csv_path}")
+                logger.info(f"CSVログ保存完了: {os.path.basename(self.csv_path)}")
                 logger.info(f"総記録数: {self.log_count}行")
+            elif self.csv_path and os.path.exists(self.csv_path):
+                logger.info(f"既存CSVファイルを保持: {os.path.basename(self.csv_path)}")
         except Exception as e:
-            logger.error(f"ログ記録エラー: {e}")
+            logger.error(f"ログクローズエラー: {e}")
 
 class VideoDistortionCorrector:
     """動画の歪み補正クラス（改良版 - yolo_checker.py準拠）"""
@@ -966,23 +1217,152 @@ class IntegratedVideoProcessor:
         # 拡張CSVロガー
         self.csv_logger = None
         self.model_path = model_path
+        # スマートファイル管理
+        self.file_manager = SmartFileManager()
 
-    def set_csv_logger(self, csv_path="enhanced_detection_log.csv"):
-        """CSVロガーを設定"""
+    def estimate_processing_time(self, video_path):
+        """動画の処理時間を推定"""
         try:
-            self.csv_logger = EnhancedCSVLogger(csv_path)
-            logger.info(f"拡張CSVロガー初期化成功: {csv_path}")
+            cap = cv2.VideoCapture(video_path)
+            if not cap.isOpened():
+                return 0
+
+            fps = cap.get(cv2.CAP_PROP_FPS)
+            total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+            width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+            height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+            cap.release()
+
+            # 基本推定式（実際の環境に応じて調整）
+            base_time_per_frame = 0.1  # 1フレームあたりの基本処理時間
+            resolution_factor = (width * height) / (1920 * 1080)
+
+            estimated_time = total_frames * base_time_per_frame * resolution_factor
+
+            logger.info(f"推定処理時間: {estimated_time:.1f}秒 ({total_frames}フレーム, {width}x{height})")
+            return estimated_time
+
         except Exception as e:
-            logger.error(f"拡張CSVロガー初期化失敗: {e}")
+            logger.warning(f"処理時間推定エラー: {e}")
+            return 0
+
+    def process_video_with_smart_management(self, input_path, show_preview=True, apply_correction=True, force_process=False):
+        """スマートファイル管理付きの動画処理（CSV保護機能強化）"""
+
+        # 処理時間を推定
+        estimated_time = self.estimate_processing_time(input_path)
+
+        # 処理すべきかを判定
+        should_process, reason, file_paths = self.file_manager.should_process_video(
+            input_path, estimated_time, force_process
+        )
+
+        if not should_process:
+            logger.info(f"⏭️  処理をスキップ: {reason}")
+
+            # 既存ファイル情報を表示（CSV保護情報を含む）
+            existing_files = self.file_manager.check_existing_files(file_paths)
+            logger.info("=== 🔒 既存ファイル保護情報 ===")
+            for key, file_info in existing_files.items():
+                size_mb = file_info["size"] / (1024 * 1024)
+                mod_time_str = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(file_info["mtime"]))
+
+                # CSVファイルの保護状況を明示
+                if "csv" in key.lower():
+                    protection_status = "🔒 保護中"
+                else:
+                    protection_status = "🔒 保護中"
+
+                logger.info(f"{key}: {os.path.basename(file_info['path'])} ({size_mb:.1f}MB, 更新: {mod_time_str}) {protection_status}")
+
+            # ユーザーに確認
+            print(f"\n🔒 既存の処理結果が品質劣化防止により保護されています。")
+            print(f"スキップ理由: {reason}")
+            print("📊 保護対象:")
+            print(f"  ・動画ファイル: {os.path.basename(file_paths.get('output_video', 'N/A'))}")
+            print(f"  ・基本CSV: {os.path.basename(file_paths.get('basic_csv', 'N/A'))}")
+            print(f"  ・拡張CSV: {os.path.basename(file_paths.get('enhanced_csv', 'N/A'))}")
+            print("\nそれでも再処理しますか？（既存の全ファイルが削除されます）")
+            user_choice = input("再処理する場合は 'y' を入力: ").lower().strip()
+
+            if user_choice != 'y':
+                logger.info("⏹️  品質劣化防止により処理をスキップしました")
+                logger.info("💡 より長い処理時間が見込まれる場合に自動実行されます")
+                return False
+
+            logger.info("🔄 ユーザー選択により品質保護を解除して再処理を実行")
+
+        # 既存ファイルをクリーンアップ（CSV含む）
+        if should_process or user_choice == 'y':
+            self.file_manager.cleanup_existing_files(file_paths)
+
+        # 実際の動画処理を実行
+        logger.info(f"📹 動画処理開始: {reason}")
+        logger.info(f"📁 出力ファイル:")
+        logger.info(f"  動画: {os.path.basename(file_paths['output_video'])}")
+        logger.info(f"  基本CSV: {os.path.basename(file_paths['basic_csv'])}")
+        logger.info(f"  拡張CSV: {os.path.basename(file_paths['enhanced_csv'])}")
+
+        # 拡張CSVロガーを設定（動画別ファイル、常に上書き）
+        try:
+            self.csv_logger = EnhancedCSVLogger(
+                file_paths["enhanced_csv"],
+                model_name=os.path.basename(self.model_path),
+                overwrite_existing=True  # 品質向上時は必ず上書き
+            )
+            logger.info(f"✅ 拡張CSVロガー初期化成功: {os.path.basename(file_paths['enhanced_csv'])}")
+        except Exception as e:
+            logger.error(f"❌ 拡張CSVロガー初期化失敗: {e}")
+            self.csv_logger = None
+
+        # 従来のprocess_videoメソッドを呼び出し
+        success = self.process_video(
+            input_path,
+            file_paths["output_video"],
+            file_paths["basic_csv"],
+            show_preview,
+            apply_correction
+        )
+
+        if success:
+            # 処理時間を記録
+            processing_time = getattr(self, '_last_processing_time', estimated_time)
+            total_frames = getattr(self, '_last_total_frames', 0)
+
+            self.file_manager.log_processing_completion(
+                input_path, file_paths, processing_time, total_frames
+            )
+
+            logger.info(f"✅ 全ファイル処理完了: {file_paths['video_basename']}")
+            logger.info("📊 保護されたファイル:")
+            logger.info(f"  ・動画: {os.path.basename(file_paths['output_video'])}")
+            logger.info(f"  ・基本CSV: {os.path.basename(file_paths['basic_csv'])}")
+            logger.info(f"  ・拡張CSV: {os.path.basename(file_paths['enhanced_csv'])}")
+
+        return success
+
+    def set_csv_logger(self, csv_path="enhanced_detection_log.csv", overwrite_existing=True):
+        """CSVロガーを設定（main.py互換性 - 品質保護対応）"""
+        try:
+            self.csv_logger = EnhancedCSVLogger(
+                csv_path,
+                model_name=os.path.basename(self.model_path),
+                overwrite_existing=overwrite_existing
+            )
+            logger.info(f"✅ 拡張CSVロガー初期化成功: {os.path.basename(csv_path)}")
+        except Exception as e:
+            logger.error(f"❌ 拡張CSVロガー初期化失敗: {e}")
             self.csv_logger = None
 
     def process_video(self, input_path, output_path, result_log="frame_results.csv",
-                    show_preview=True, apply_correction=True):
-        """動画を処理（改良版）"""
+                            show_preview=True, apply_correction=True):
+        """動画を処理（main.py互換性メソッド）"""
+        start_time = time.time()
+
         cap = cv2.VideoCapture(input_path)
         if not cap.isOpened():
             logger.error(f"動画ファイルを開けません: {input_path}")
-            return
+            return False
 
         # 動画情報取得
         width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
@@ -1005,97 +1385,102 @@ class IntegratedVideoProcessor:
         os.makedirs(os.path.dirname(result_log), exist_ok=True)
         detection_count = 0
 
-        with open(result_log, 'w', newline='') as f:
-            writer = csv.writer(f)
-            writer.writerow([
-                "frame", "tracking_id", "using_phone", "grid_row", "grid_col",
-                "yolo_confidence", "avg_keypoint_confidence", "overall_confidence", "visible_keypoints"
-            ])
+        try:
+            with open(result_log, 'w', newline='') as f:
+                writer = csv.writer(f)
+                writer.writerow([
+                    "frame", "tracking_id", "using_phone", "grid_row", "grid_col",
+                    "yolo_confidence", "avg_keypoint_confidence", "overall_confidence", "visible_keypoints"
+                ])
 
-            frame_idx = 0
-            start_time = time.time()
+                frame_idx = 0
+                logger.info("改良版動画処理を開始...")
 
-            logger.info("改良版動画処理を開始...")
-
-            while True:
-                ret, frame = cap.read()
-                if not ret:
-                    break
-
-                frame_idx += 1
-
-                # 歪み補正適用
-                if apply_correction:
-                    frame = self.corrector.apply_correction(frame)
-
-                # 姿勢検出処理
-                try:
-                    frame = self.detector.process_frame(
-                        frame, frame_idx, writer, self.csv_logger
-                    )
-
-                    # 検出結果をカウント
-                    if self.csv_logger and hasattr(self.csv_logger, 'log_count'):
-                        detection_count = self.csv_logger.log_count
-
-                except Exception as detection_error:
-                    logger.error(f"フレーム{frame_idx}処理エラー: {detection_error}")
-
-                # フレーム情報表示
-                cv2.putText(frame, f"Frame: {frame_idx}/{total_frames}", (20, 40),
-                        cv2.FONT_HERSHEY_SIMPLEX, 1, (255, 255, 0), 2)
-
-                # キーポイント信頼度情報表示
-                cv2.putText(frame, f"Keypoint-based Detection", (20, 80),
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 255), 2)
-
-                # 拡張CSV記録状況表示
-                if self.csv_logger:
-                    cv2.putText(frame, f"Enhanced CSV: {detection_count} records", (20, 80),
-                            cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 255), 2)
-
-                # プレビュー表示
-                if show_preview:
-                    cv2.imshow("Advanced Posture Detection System", frame)
-                    if cv2.waitKey(1) & 0xFF == ord('q'):
-                        logger.info("処理が中断されました")
+                while True:
+                    ret, frame = cap.read()
+                    if not ret:
                         break
 
-                # 結果保存
-                out.write(frame)
+                    frame_idx += 1
 
-                # 進行状況表示
-                if frame_idx % 30 == 0:
-                    elapsed = time.time() - start_time
-                    fps_current = frame_idx / elapsed
-                    progress = (frame_idx / total_frames) * 100
-                    eta = (total_frames - frame_idx) / fps_current if fps_current > 0 else 0
+                    # 歪み補正適用
+                    if apply_correction:
+                        frame = self.corrector.apply_correction(frame)
 
-                    active_tracks = self.detector.id_tracker.get_active_tracks()
-                    logger.info(
-                        f"進行状況: {progress:.1f}% ({frame_idx}/{total_frames}) "
-                        f"処理速度: {fps_current:.1f}fps 残り: {eta:.1f}s "
-                        f"アクティブID: {sorted(active_tracks.keys())} "
-                        f"拡張CSV: {detection_count}行"
-                    )
+                    # 姿勢検出処理
+                    try:
+                        frame = self.detector.process_frame(
+                            frame, frame_idx, writer, self.csv_logger
+                        )
 
-        # リソース解放
-        cap.release()
-        out.release()
-        cv2.destroyAllWindows()
+                        # 検出結果をカウント
+                        if self.csv_logger and hasattr(self.csv_logger, 'log_count'):
+                            detection_count = self.csv_logger.log_count
 
-        # CSVロガーをクローズ
-        if self.csv_logger:
-            self.csv_logger.close()
+                    except Exception as detection_error:
+                        logger.error(f"フレーム{frame_idx}処理エラー: {detection_error}")
+
+                    # フレーム情報表示
+                    cv2.putText(frame, f"Frame: {frame_idx}/{total_frames}", (20, 40),
+                            cv2.FONT_HERSHEY_SIMPLEX, 1, (255, 255, 0), 2)
+
+                    # 拡張CSV記録状況表示
+                    if self.csv_logger:
+                        cv2.putText(frame, f"Enhanced CSV: {detection_count} records", (20, 80),
+                                cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 255, 255), 2)
+
+                    # プレビュー表示
+                    if show_preview:
+                        cv2.imshow("Advanced Posture Detection System", frame)
+                        if cv2.waitKey(1) & 0xFF == ord('q'):
+                            logger.info("処理が中断されました")
+                            break
+
+                    # 結果保存
+                    out.write(frame)
+
+                    # 進行状況表示
+                    if frame_idx % 30 == 0:
+                        elapsed = time.time() - start_time
+                        fps_current = frame_idx / elapsed
+                        progress = (frame_idx / total_frames) * 100
+                        eta = (total_frames - frame_idx) / fps_current if fps_current > 0 else 0
+
+                        active_tracks = self.detector.id_tracker.get_active_tracks()
+                        logger.info(
+                            f"進行状況: {progress:.1f}% ({frame_idx}/{total_frames}) "
+                            f"処理速度: {fps_current:.1f}fps 残り: {eta:.1f}s "
+                            f"アクティブID: {sorted(active_tracks.keys())} "
+                            f"拡張CSV: {detection_count}行"
+                        )
+
+        except Exception as e:
+            logger.error(f"動画処理エラー: {e}")
+            return False
+        finally:
+            # リソース解放
+            cap.release()
+            out.release()
+            cv2.destroyAllWindows()
+
+            # CSVロガーをクローズ
+            if self.csv_logger:
+                self.csv_logger.close()
+
+        # 処理時間と統計を記録
+        processing_time = time.time() - start_time
+        self._last_processing_time = processing_time
+        self._last_total_frames = frame_idx
 
         # 完了報告
-        total_time = time.time() - start_time
         logger.info(f"🎉 改良版動画処理完了!")
-        logger.info(f"処理時間: {total_time:.1f}秒")
-        logger.info(f"平均処理速度: {frame_idx/total_time:.1f}fps")
+        logger.info(f"処理時間: {processing_time:.1f}秒")
+        logger.info(f"平均処理速度: {frame_idx/processing_time:.1f}fps")
         logger.info(f"最終拡張CSV記録数: {detection_count}行")
 
-    def get_statistics(self) -> Dict:
+        return True
+
+    def get_statistics(self) -> dict:
         """処理統計を取得"""
         active_tracks = self.detector.id_tracker.get_active_tracks()
         return {


### PR DESCRIPTION
処理ファイルの名前をもとに出力することで、違う動画のデータが上書きされることのないように処理
推論時間などによる自動上書きの防止は行えていないので、ある程度処理が完了したら別のフォルダに移して保存する必要がある